### PR TITLE
devenv: migrate from `SHCopyFile` to `IFileOperation`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,15 @@ let SwiftDevEnv = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser",
              .upToNextMinor(from: "0.3.0")),
+    .package(name: "SwiftCOM", url: "https://github.com/compnerd/swift-com",
+             .branch("master")),
   ],
   targets: [
     .target(
       name: "devenv",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftCOM", package: "SwiftCOM"),
       ],
       swiftSettings: [
         .unsafeFlags(["-parse-as-library"]),

--- a/Sources/devenv/Extensions/WinSDK+Extensions.swift
+++ b/Sources/devenv/Extensions/WinSDK+Extensions.swift
@@ -17,3 +17,13 @@ internal var KEY_READ: DWORD {
 internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
   return DWORD((s << 10) | p)
 }
+
+@_transparent
+internal func HRESULT_FACILITY(_ hr: HRESULT) -> WORD {
+  return WORD((Int32(hr) >> 16) & 0x1fff)
+}
+
+@_transparent
+internal func HRESULT_CODE(_ hr: HRESULT) -> WORD {
+  return WORD(Int32(hr) & 0xffff)
+}


### PR DESCRIPTION
This migrates to the newer Shell operation.  This now requires COM but
provides a much nicer UAC elevation behaviour without necessarily
flashing the copy dialog.  Additionally, it is a much better example of
a native windows application that is fully using the native system
mechanisms.