### PR TITLE
devenv: correct a typo (NFC)

### DIFF
--- a/Sources/devenv/main.swift
+++ b/Sources/devenv/main.swift
@@ -16,7 +16,7 @@ private func WIN32_FROM_HRESULT(_ hr: HRESULT) -> WORD? {
 }
 
 fileprivate var szWindowsKitsInstalledRootsKey: String {
-  "SOFTWARE\\Microsoft\\WIndows Kits\\Installed Roots"
+  "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots"
 }
 
 fileprivate var szKitsRoot10: String {


### PR DESCRIPTION
The key is "Windows Kits", correct the incorrect case.

Thanks to @lxbndr for pointing out the accidental typo in the case!